### PR TITLE
Fix npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A go style channel implementation that works nicely with co",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`node_modules/.bin` is in `$PATH`, so `mocha` is available in every `npm` script
